### PR TITLE
add docs for the block2 DMRG solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,16 @@ echo 'export PYSCF_EXT_PATH=/home/abc/local/path:$PYSCF_EXT_PATH' >> ~/.bashrc
 ```
 
 You can find more details of extended modules in the document
-[extension modules](http://pyscf.org/pyscf/install.html#extension-modules)
+[extension modules](http://pyscf.org/install.html#extension-modules)
 
 * Using DMRG as the FCI solver for CASSCF.  There are two DMRG solver
   interfaces implemented in this module
 
-      Block (https://pyscf.org/Block/)
+      Block (https://pyscf.org/Block/) or block2 (https://pypi.org/project/block2/)
       CheMPS2 (https://github.com/SebWouters/CheMPS2)
 
   After installing the DMRG solver, create a file dmrgscf/settings.py
   to store the path where the DMRG solver was installed.
+
+  Detailed instruction for using ``StackBlock`` or ``block2`` as the DMRG solver for CASSCF
+  can be found in this [documentation](https://block2.readthedocs.io/en/latest/user/dmrg-scf.html).

--- a/examples/01-dmrg_casscf_with_stackblock.py
+++ b/examples/01-dmrg_casscf_with_stackblock.py
@@ -15,7 +15,7 @@ rest keywords are all compatible to the old Block program.
 The new block2 code (https://github.com/block-hczhai/block2-preview)
 can be more efficient than Block-1.5 (stackblock) for max bond dim < 2000,
 and for larger bond dimension they provide similar efficiency.
-The DMRGSCF interface for block2 and stackblock are the same.
+The DMRGSCF interface for block2 and stackblock is the same.
 '''
 
 from pyscf import lib

--- a/examples/01-dmrg_casscf_with_stackblock.py
+++ b/examples/01-dmrg_casscf_with_stackblock.py
@@ -11,6 +11,11 @@ This example shows how to input new defined keywords for stackblock program.
 
 Block-1.5 (stackblock) defines two new keywords memory and num_thrds.  The
 rest keywords are all compatible to the old Block program.
+
+The new block2 code (https://github.com/block-hczhai/block2-preview)
+can be more efficient than Block-1.5 (stackblock) for max bond dim < 2000,
+and for larger bond dimension they provide similar efficiency.
+The DMRGSCF interface for block2 and stackblock are the same.
 '''
 
 from pyscf import lib

--- a/pyscf/dmrgscf/dmrgci.py
+++ b/pyscf/dmrgscf/dmrgci.py
@@ -777,7 +777,7 @@ class DMRGCI(lib.StreamObject):
 
 # Block code also allows non-spin-adapted calculation. S^2 is not available in
 # this type of calculation
-    if 'spin_adapted' in settings.BLOCKEXE:
+    if 'spin_adapted' in settings.BLOCKEXE or 'block2main' in settings.BLOCKEXE:
         def spin_square(self, civec, norb, nelec):
             if isinstance(nelec, (int, numpy.integer)):
                 nelecb = nelec//2


### PR DESCRIPTION
* Added docs for the block2 DMRG solver in README and example comments
* Fixed the broken link to ``extension modules`` in README
* Enabled ``spin_square`` method in DMRGCI when ``block2main`` is used as the ``BLOCKEXE``