### PR TITLE
bug fix 'is not []' to '!= []'

### DIFF
--- a/pyscf/dmrgscf/dmrgci.py
+++ b/pyscf/dmrgscf/dmrgci.py
@@ -908,7 +908,7 @@ def writeIntegralFile(DMRGCI, h1eff, eri_cas, ncas, nelec, ecore=0):
 
     # The name of the FCIDUMP file, default is "FCIDUMP".
     integralFile = os.path.join(DMRGCI.runtimeDir, DMRGCI.integralFile)
-    if DMRGCI.groupname is not None and DMRGCI.orbsym is not []:
+    if DMRGCI.groupname is not None and DMRGCI.orbsym != []:
 # First removing the symmetry forbidden integrals. This has been done using
 # the pyscf internal irrep-IDs (stored in DMRGCI.orbsym)
         orbsym = numpy.asarray(DMRGCI.orbsym) % 10


### PR DESCRIPTION
Hi, I faced following error
```python
pyscf/submodules/dmrgscf/pyscf/dmrgscf/dmrgci.py", line 915, in writeIntegralFile
    pair_irrep = (orbsym.reshape(-1,1) ^ orbsym)[numpy.tril_indices(ncas)]
                  ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
TypeError: ufunc 'bitwise_xor' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

This occurs when `DMRGCI.orbsym==[]`. This should be addressed by replacig
```python
 911     if DMRGCI.groupname is not None and DMRGCI.orbsym is not []:
```
to
```python
 911     if DMRGCI.groupname is not None and DMRGCI.orbsym != []:
```